### PR TITLE
Mocks health endpoint

### DIFF
--- a/__tests__/health/mocks/syntax.js
+++ b/__tests__/health/mocks/syntax.js
@@ -1,0 +1,26 @@
+const { withServer, resolveMockFile } = require('../../../testUtils/server');
+const waitForExpect = require('wait-for-expect');
+
+it('tells when mocks could not be loaded', () => withServer({
+  '--mocks': resolveMockFile('health/mocks/syntax/correct.js'),
+  '--port': 3000,
+}, async ({ client, setMocksFile }) => {
+  await waitForExpect(async () => {
+    expect((await client.get('/s/ping')).data).toEqual('pong');
+    expect((await client.get('/admin/health/mocks')).status).toEqual(200);
+  });
+
+  setMocksFile(resolveMockFile('health/mocks/syntax/incorrect.js'));
+
+  await waitForExpect(async () => {
+    expect((await client.get('/s/ping')).status).toEqual(404);
+    expect((await client.get('/admin/health/mocks')).status).toEqual(500);
+  });
+
+  setMocksFile(resolveMockFile('health/mocks/syntax/different_correct.js'));
+  
+  await waitForExpect(async () => {
+    expect((await client.get('/s/ping')).data).toEqual('PONG!');
+    expect((await client.get('/admin/health/mocks')).status).toEqual(200);
+  });
+}));

--- a/__tests__/health/mocks/syntax.js
+++ b/__tests__/health/mocks/syntax.js
@@ -10,11 +10,16 @@ it('tells when mocks could not be loaded', () => withServer({
     expect((await client.get('/admin/health/mocks')).status).toEqual(200);
   });
 
+  let delayedRequestResponseCode;
+  client.get('/s/delayed')
+    .then((res) => delayedRequestResponseCode = res.status);
+
   setMocksFile(resolveMockFile('health/mocks/syntax/incorrect.js'));
 
   await waitForExpect(async () => {
     expect((await client.get('/s/ping')).status).toEqual(404);
     expect((await client.get('/admin/health/mocks')).status).toEqual(500);
+    expect(delayedRequestResponseCode).toEqual(400);
   });
 
   setMocksFile(resolveMockFile('health/mocks/syntax/different_correct.js'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "endpoint-imposter",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1770,7 +1770,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1791,12 +1792,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1811,17 +1814,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1938,7 +1944,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1950,6 +1957,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1964,6 +1972,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1971,12 +1980,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1995,6 +2006,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2075,7 +2087,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2087,6 +2100,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2172,7 +2186,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2208,6 +2223,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2227,6 +2243,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2270,12 +2287,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "endpoint-imposter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "main": "src/index.js",
   "bin": {

--- a/src/admin.js
+++ b/src/admin.js
@@ -39,8 +39,7 @@ const makeSingleReleaseCb = keyToRelease => {
   };
 };
 
-module.exports = ({ sessions }) => {
-
+module.exports = ({ sessions, mocksHealth }) => {
   const updatePendingResponses = ({
     filter, action, sessionId, responseGenerator
   }) => {
@@ -105,6 +104,11 @@ module.exports = ({ sessions }) => {
       case 'terminated':
         return res.status(200).send();
     }
+  });
+
+  app.get('/health/mocks', (req, res) => {
+    const status = mocksHealth.read() ? 200 : 500;
+    return res.status(status).send();
   });
 
   return app;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 const { makeSessions, getTransitionCount, transition } = require('./sessions');
 const makeAdminApp = require('./admin');
-const { watchMockConfig, unifyMockConfig, mockMatches, prepareRequestForMatching } = require('./mocks');
+const { watchMockConfig, unifyMockConfig, mockMatches, prepareRequestForMatching, makeMocksHealthService } = require('./mocks');
 
 const argv = minimist(process.argv.slice(2));
 
@@ -24,7 +24,6 @@ const httpsOptions = {
 };
 
 const sessions = makeSessions();
-const adminApp = makeAdminApp({ sessions });
 
 // TODO: extract somewhere
 const transitionActions = (session, mock) => {
@@ -111,10 +110,16 @@ const makeMockRouter = mockConfig => {
   return mockRouter;
 };
 
+const mocksHealth = makeMocksHealthService();
+
 let mockRouter;
 watchMockConfig(mocksPath, config => {
   sessions.terminateAllSessions();
   mockRouter = makeMockRouter(unifyMockConfig(config));
+  mocksHealth.set(true);
+}, () => {
+  mockRouter = makeMockRouter(unifyMockConfig([]));
+  mocksHealth.set(false);
 });
 
 const sessionIdMiddleware = (req, res, next) => {
@@ -124,6 +129,7 @@ const sessionIdMiddleware = (req, res, next) => {
 
 const app = express();
 
+const adminApp = makeAdminApp({ sessions, mocksHealth });
 app.use('/admin', adminApp);
 app.use('/:sessionId', [sessionIdMiddleware, (...args) => mockRouter(...args)]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ watchMockConfig(mocksPath, config => {
   mockRouter = makeMockRouter(unifyMockConfig(config));
   mocksHealth.set(true);
 }, () => {
+  sessions.terminateAllSessions();
   mockRouter = makeMockRouter(unifyMockConfig([]));
   mocksHealth.set(false);
 });

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -3,12 +3,21 @@ const sift = require('sift').default;
 const importFresh = require('import-fresh');
 const { getScenarioStep } = require('./sessions.js');
 
-const watchMockConfig = (filename, cb) => {
+const makeMocksHealthService = () => {
+  let healthy = true;
+  return {
+    read: () => healthy,
+    set: newValue => healthy = newValue,
+  };
+};
+
+const watchMockConfig = (filename, cb, onError) => {
   const loadFresh = () => {
     try {
       const config = importFresh(filename);
       cb(config);
     } catch (e) {
+      onError();
       console.error('Unable to load the mocks.');
       console.error(e);
     }
@@ -115,4 +124,5 @@ module.exports = {
   unifyMockConfig,
   mockMatches,
   prepareRequestForMatching,
+  makeMocksHealthService,
 };

--- a/testutils/mocks/health/mocks/syntax/correct.js
+++ b/testutils/mocks/health/mocks/syntax/correct.js
@@ -1,0 +1,6 @@
+module.exports = [
+  {
+    request: { path: '/ping' },
+    response: { body: 'pong' },
+  }
+];

--- a/testutils/mocks/health/mocks/syntax/correct.js
+++ b/testutils/mocks/health/mocks/syntax/correct.js
@@ -2,5 +2,9 @@ module.exports = [
   {
     request: { path: '/ping' },
     response: { body: 'pong' },
-  }
+  },
+  {
+    request: { path: '/delayed' },
+    releaseOn: 'give-delayed',
+  },
 ];

--- a/testutils/mocks/health/mocks/syntax/different_correct.js
+++ b/testutils/mocks/health/mocks/syntax/different_correct.js
@@ -1,0 +1,6 @@
+module.exports = [
+  {
+    request: { path: '/ping' },
+    response: { body: 'PONG!' },
+  }
+];

--- a/testutils/mocks/health/mocks/syntax/incorrect.js
+++ b/testutils/mocks/health/mocks/syntax/incorrect.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    request: { path: '/ping' },
+    response: { body: 'pong' },
+  }
+  ain't no valid JS
+];


### PR DESCRIPTION
Calling `/admin/health/mocks` results in the 500 error code if the mocks cannot be loaded.

Also, if the new mocks aren't properly loaded, the old ones are deregistered. Like if there was not a single mock.